### PR TITLE
QoL updates

### DIFF
--- a/anyrun.nix
+++ b/anyrun.nix
@@ -1,0 +1,39 @@
+{
+  config,
+  pkgs,
+  inputs,
+  ...
+}: {
+  imports = [
+    inputs.anyrun.homeManagerModules.default
+  ];
+  programs.anyrun = {
+    enable = true;
+    config = {
+      plugins = with inputs.anyrun.packages.${pkgs.system}; [
+        applications
+        rink
+        symbols
+        randr
+      ];
+      closeOnClick = false;
+      showResultsImmediately = false;
+      maxEntries = 20;
+      width.fraction = 0.3;
+      x.fraction = 0.5;
+      y.fraction = 0.1;
+    };
+    extraCss = ''
+      label#match-desc {
+        font-size: 10px;
+      }
+
+      label#plugin {
+        font-size: 14px;
+      }
+      #window {
+        background-color = transparent;
+      }
+    '';
+  };
+}

--- a/configuration.nix
+++ b/configuration.nix
@@ -156,6 +156,11 @@
     hyprland = {
       enable = true;
     };
+    nh = {
+      enable = true;
+      clean.enable = true;
+      clean.extraArgs = "--keep-since 10d --keep 5";
+    };
   };
 
   services = {
@@ -234,6 +239,16 @@
       extraGroups = [ "wheel" "networkmanager" "libvirtd" "video" ];
       hashedPassword = "$y$j9T$PPMehWHX4aaQ5oMN3igBV0$zXYtqyL4ez7knABEGRMIYTPk1YERI/aY/qOaxXXq1q5";
     };
+  };
+
+    # Use wayland pls uwu
+  environment.sessionVariables = {
+    NIXOS_OZONE_WL = "1";
+    GDK_BACKEND = "wayland,x11";
+    QT_QPA_PLATFORM = "wayland;xcb";
+    SDL_VIDEODRIVER = "wayland";
+    CLUTTER_BACKEND = "wayland";
+    MOZ_ENABLE_WAYLAND = "1";
   };
 
   environment = {

--- a/configuration.nix
+++ b/configuration.nix
@@ -98,7 +98,7 @@
   networking = {
     hostName = "mars-monkey-laptop";
     hostId = "8425e349";
-    networkmanager.enable = true;
+    wireless.iwd.enable = true;
     nameservers = ["1.1.1.3" "1.0.0.3"];
 
     firewall = {

--- a/configuration.nix
+++ b/configuration.nix
@@ -120,13 +120,6 @@
       automatic = true;
       dates = ["daily"];
     };
-    
-    gc = {
-      automatic = true;
-      persistent = true;
-      dates = "daily";
-      options = "--delete-older-than 3d";
-    };
 
     settings = {
       trusted-users = ["@wheel"];

--- a/flake.lock
+++ b/flake.lock
@@ -1,5 +1,26 @@
 {
   "nodes": {
+    "anyrun": {
+      "inputs": {
+        "flake-parts": "flake-parts",
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1713259062,
+        "narHash": "sha256-WTO84hUL8IlNuHDK2yOCeJ38EewFzGt5E0kzBjNWxa8=",
+        "owner": "anyrun-org",
+        "repo": "anyrun",
+        "rev": "f9d30e34fa4ccb2797c6becec37e8bcff6585d39",
+        "type": "github"
+      },
+      "original": {
+        "owner": "anyrun-org",
+        "repo": "anyrun",
+        "type": "github"
+      }
+    },
     "devshell": {
       "inputs": {
         "flake-utils": "flake-utils",
@@ -53,6 +74,27 @@
       }
     },
     "flake-parts": {
+      "inputs": {
+        "nixpkgs-lib": [
+          "anyrun",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1696343447,
+        "narHash": "sha256-B2xAZKLkkeRFG5XcHHSXXcP7To9Xzr59KXeZiRf4vdQ=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "c9afaba3dfa4085dbd2ccb38dfade5141e33d9d4",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "flake-parts_2": {
       "inputs": {
         "nixpkgs-lib": [
           "nixvim",
@@ -214,7 +256,7 @@
       "inputs": {
         "devshell": "devshell",
         "flake-compat": "flake-compat",
-        "flake-parts": "flake-parts",
+        "flake-parts": "flake-parts_2",
         "home-manager": "home-manager_2",
         "nix-darwin": "nix-darwin",
         "nixpkgs": [
@@ -266,6 +308,7 @@
     },
     "root": {
       "inputs": {
+        "anyrun": "anyrun",
         "home-manager": "home-manager",
         "nixpkgs": "nixpkgs",
         "nixvim": "nixvim"

--- a/flake.nix
+++ b/flake.nix
@@ -21,6 +21,7 @@
   };
 
   outputs = { nixpkgs, ... }@inputs: {
+    formatter.x86_64-linux = nixpkgs.legacyPackages.x86_64-linux.alejandra;
     nixosConfigurations."mars-monkey-laptop" = nixpkgs.lib.nixosSystem {
       specialArgs = { inherit inputs; };
 

--- a/flake.nix
+++ b/flake.nix
@@ -13,6 +13,11 @@
       url = "github:nix-community/nixvim";
       inputs.nixpkgs.follows = "nixpkgs";
     };
+
+    anyrun = {
+      url = "github:anyrun-org/anyrun";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
   };
 
   outputs = { nixpkgs, ... }@inputs: {

--- a/home.nix
+++ b/home.nix
@@ -5,6 +5,7 @@
     inputs.nixvim.homeManagerModules.nixvim
     ./waybar.nix
     ./hyprlock.nix
+    ./anyrun.nix
   ];
 
   home = {

--- a/home.nix
+++ b/home.nix
@@ -37,7 +37,6 @@
    
     sessionVariables = {
       EDITOR = "nvim";
-      MOZ_ENABLE_WAYLAND = "1";
     };
     
     pointerCursor = {
@@ -136,8 +135,9 @@
     enable = true;
 
     settings = {
-      monitor = ",preferred,auto,1";
+      monitor = ",highres,auto,1";
       "$terminal" = "kitty";
+      xwayland.force_zero_scaling = true;
       
 
       input = {
@@ -155,7 +155,6 @@
         layout = "dwindle";
         allow_tearing = "true";
       };
-
       decoration = {
         rounding = "10";
         drop_shadow = "yes";
@@ -220,7 +219,7 @@
         "$mod, R, exec, $menu"
         "$mod, P, pseudo,"
         "$mod, O, togglesplit,"
-        ", Print, exec, grimblast copy"
+        ", Print, exec, grimblast copysave area"
         
         "$mod, H, movefocus, l"
         "$mod, L, movefocus, r"
@@ -254,6 +253,12 @@
         "$mod, mouse_down, workspace, e-1"
         "$mod, mouse_up, workspace, e+1"
 
+        # Reload hyprland
+        "CTRL + ALT, delete, exec, hyprctl reload && systemctl restart --user waybar hypridle"
+        "$mod SPACE, exec, anyrun"
+      ];
+      binde = [
+        ",XF86AudioMute, exec, wpctl set-mute @DEFAULT_SINK@ toggle"
         ",XF86AudioRaiseVolume, exec, wpctl set-volume -l 1.0 @DEFAULT_SINK@ 5%+"
         ",XF86AudioLowerVolume, exec, wpctl set-volume -l 1.0 @DEFAULT_SINK@ 5%-"
 
@@ -264,6 +269,13 @@
       bindm = [
         "$mod, mouse:272, movewindow"
         "$mod, mouse:273, resizewindow"
+      ];
+      windowrulev2 = [
+        "float, move onscreen 50% 50%, class:io.github.kaii_lb.Overskride" # Make overskride/iwgtk a popup window, move out later
+        "float, move onscreen 50% 50%, class:org.twosheds.iwgtk"
+        "float, move onscreen 50% 50%, class:iwgtk" # For the password prompt
+
+        "bordercolor $red,xwayland:1" # Set the bordercolor to red if window is Xwayland
       ];
     };
   };

--- a/home.nix
+++ b/home.nix
@@ -131,10 +131,22 @@
 
   fonts.fontconfig.enable = true;
   
+  # Hyprland catppuccin style
+  home.file.".config/hypr/mocha.conf".source =
+    pkgs.fetchFromGitHub {
+      owner = "catppuccin";
+      repo = "hyprland";
+      rev = "v1.3";
+      hash = "sha256-jkk021LLjCLpWOaInzO4Klg6UOR4Sh5IcKdUxIn7Dis=";
+    }
+    + "/themes/mocha.conf";
   wayland.windowManager.hyprland = {
     enable = true;
 
     settings = {
+      source = [
+        "~/.config/hypr/mocha.conf"
+      ];
       monitor = ",highres,auto,1";
       "$terminal" = "kitty";
       xwayland.force_zero_scaling = true;
@@ -150,8 +162,8 @@
         gaps_in = "5";
         gaps_out = "10";
         border_size = "3";
-        "col.active_border" = "rgba(33ccffee) rgba(00ff99ee) 45deg";
-        "col.inactive_border" = "rgba(595959aa)";
+        "col.active_border" = "$mauve";
+        "col.inactive_border" = "$surface0";
         layout = "dwindle";
         allow_tearing = "true";
       };
@@ -160,7 +172,7 @@
         drop_shadow = "yes";
         shadow_range = "4";
         shadow_render_power = "3";
-        "col.shadow" = "rgba(1a1a1aee)";
+        "col.shadow" = "$surface1";
 
         blur = {
           enabled = "true";


### PR DESCRIPTION
- Added `nh`
- Added `anyrun`
    - Launch with `$mod` + `<space>`
- Added and fixed some media keybinds (press and hold to repeat volume works now)
- Added reload hyprland/waybar keybind (`ctrl + alt + delete`)
- Select area/window/screen with grimblast, also save to disk (not just clipboard)
- Replace `wpa_supplicant` with `iwd` (When rebuilding, use `nixos-rebuild boot --flake .` to prevent crashing)
- QoL Xwayland changes (change border color to red when window is running on xwayland, prevent fractional scaling to circumvent blurriness)
- Add catpuccin hyprland